### PR TITLE
Restoring stage image to MigrationController CR instead of ConfigMap

### DIFF
--- a/02-Stage-Pods/02-stage-pod-restore.sh
+++ b/02-Stage-Pods/02-stage-pod-restore.sh
@@ -4,9 +4,9 @@ img=$(cat current_image)
 
 echo "$img"
 
-oc patch configmap/migration-cluster-config \
+oc patch migrationcontroller/migration-controller \
   -n openshift-migration \
   --type merge \
-  -p '{ "data": { "STAGE_IMAGE": "'$img'" } }'
+  -p '{ "spec": {"migration_stage_image_fqin": "'$img'" }}'
 
 rm current_image


### PR DESCRIPTION
@pranavgaikwad I think we want to update the Operator's CR and allow it to update the ConfigMap.

When I ran the original version it wasn't working for me as I think the Operator was updating the configmap a little while later to the broken value.